### PR TITLE
Fix version check

### DIFF
--- a/nonechucks/__init__.py
+++ b/nonechucks/__init__.py
@@ -9,11 +9,10 @@ logger = logging.getLogger(__name__)
 
 def _get_pytorch_version():
     version = torch.__version__
-    major, minor = [x for x in version.split(".")[:2]]
-    if minor.contains('+'):
-        minor = minor[:minor.index('+')]
-    major = int(major)
-    minor = int(minor)
+    if '+' in version:
+        # e.g. 1.6.0+cu101
+        version = version[:version.index('+')]
+    major, minor = [int(x) for x in version.split(".")[:2]]
     if major != 1:
         raise RuntimeError(
             "nonechucks only supports PyTorch major version 1 at the moment."

--- a/nonechucks/__init__.py
+++ b/nonechucks/__init__.py
@@ -9,7 +9,11 @@ logger = logging.getLogger(__name__)
 
 def _get_pytorch_version():
     version = torch.__version__
-    major, minor = [int(x) for x in version.split(".")[:2]]
+    major, minor = [x for x in version.split(".")[:2]]
+    if minor.contains('+'):
+        minor = minor[:minor.index('+')]
+    major = int(major)
+    minor = int(minor)
     if major != 1:
         raise RuntimeError(
             "nonechucks only supports PyTorch major version 1 at the moment."


### PR DESCRIPTION
I am using pytorch `1.6.0+cu101`, which excepts on your version check code. The simple fix is to remove the suffix.

Thank you!