### PR TITLE
Add option to only catch intentionally raised exceptions

### DIFF
--- a/nonechucks/__init__.py
+++ b/nonechucks/__init__.py
@@ -41,3 +41,4 @@ else:
 from nonechucks.dataset import SafeDataset
 from nonechucks.sampler import SafeSampler
 from nonechucks.dataloader import SafeDataLoader
+from nonechucks.utils import NoneChucksSkipException

--- a/nonechucks/utils.py
+++ b/nonechucks/utils.py
@@ -12,6 +12,10 @@ except ImportError:
 from torch._six import string_classes
 
 
+class NoneChucksSkipException(Exception):
+    None  # ...Chucks
+
+
 class memoize(object):
     """cache the return value of a method
 


### PR DESCRIPTION
So there might be a simpler way to do this, but: 

I have a dataset where I weed out bad samples through heuristics/geometry and explicitly raise an error when one of the checks doesn't pass. Then as I was hacking on it I got really confused before I realized "doh, Nonechucks is catching *all* my exceptions!" 

So this is my solution: add an option where it'll only not raise an error if it gets a NoneChucksSkipException. This solution probably sucks, and if you want to reject it and say "no, do Y instead" I'd love to hear it